### PR TITLE
Fix rotateImgAction malposition caused by currIndex

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -1268,7 +1268,7 @@ class MainWindow(QMainWindow):
             )
 
     def rotateImgAction(self, k=1, _value=False):
-        filename = self.mImgList[self.currIndex]
+        filename = self.filePath
 
         if os.path.exists(filename):
             if self.itemsToShapesbox:


### PR DESCRIPTION
Obtain the current file path using self.filePath