### PR TITLE
bug fix for PPOCRLabel.exportJSON NameError: name 'null' is not defined

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -3035,7 +3035,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace("false", "False")
                         label = label.replace("true", "True")
-                        label = label.replace('null', 'None')
+                        label = label.replace("null", "None")
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []
@@ -3183,7 +3183,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace("false", "False")
                         label = label.replace("true", "True")
-                        label = label.replace('null', 'None')
+                        label = label.replace("null", "None")
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -3035,6 +3035,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace("false", "False")
                         label = label.replace("true", "True")
+                        label = label.replace('null', 'None')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []
@@ -3182,6 +3183,7 @@ class MainWindow(QMainWindow):
                     if label:
                         label = label.replace("false", "False")
                         label = label.replace("true", "True")
+                        label = label.replace('null', 'None')
                         labeldict[file] = eval(label)
                     else:
                         labeldict[file] = []


### PR DESCRIPTION
解决识别文本概率出现null导致导出表格标注时闪退的问题
![231083799-d1ab3e8e-671f-4e49-b6cf-367e137d5c4d](https://github.com/user-attachments/assets/1c39eeef-34e8-447b-81b2-9793a23196bf)
