### PR TITLE
fix ten line token convert bug

### DIFF
--- a/libs/utils.py
+++ b/libs/utils.py
@@ -233,10 +233,10 @@ def convert_token(html_list):
                 token_list.append("<td")
                 if "colspan" in col:
                     _, n = col.split("colspan=")
-                    token_list.append(' colspan="{}"'.format(n[0]))
+                    token_list.append(' colspan="{}"'.format(str(int(n[0]))))
                 if "rowspan" in col:
                     _, n = col.split("rowspan=")
-                    token_list.append(' rowspan="{}"'.format(n[0]))
+                    token_list.append(' rowspan="{}"'.format(str(int(n[0]))))
                 token_list.extend([">", "</td>"])
         token_list.append("</tr>")
     token_list.append("</tbody>")


### PR DESCRIPTION
PPOCRLabel/libs/utils.py中的convert_token方法中
col.split()返回值n为str类型，在下方token_list.append中，只对n的第一位进行format