### PR TITLE
解决导出表格标注时遇到的通用问题

### DIFF
--- a/libs/utils.py
+++ b/libs/utils.py
@@ -205,14 +205,16 @@ def expand_list(merged, html_list):
     Fill blanks according to merged cells
     """
     sr, er, sc, ec = merged
-    for i in range(sr, er):
-        for j in range(sc, ec):
+    # Fill the range of merged cells with None
+    for i in range(sr, er + 1):
+        for j in range(sc, ec + 1):
             html_list[i][j] = None
+    # Add the colspan and rowspan attributes only if necessary
     html_list[sr][sc] = ""
-    if ec - sc > 1:
-        html_list[sr][sc] += " colspan={}".format(ec - sc)
-    if er - sr > 1:
-        html_list[sr][sc] += " rowspan={}".format(er - sr)
+    if ec - sc > 0:  # Only add colspan if the column span is more than 1
+        html_list[sr][sc] += ' colspan={}'.format(ec - sc + 1)
+    if er - sr > 0:  # Only add rowspan if the row span is more than 1
+        html_list[sr][sc] += ' rowspan={}'.format(er - sr + 1)
     return html_list
 
 
@@ -257,6 +259,7 @@ def rebuild_html_from_ppstructure_label(label_info):
             cell = "".join(cell)
             html_code.insert(i + 1, cell)
     html_code = "".join(html_code)
+    html_code = re.sub(r'(colspan|rowspan)="(\d+)"', r'\1=\2', html_code)
     html_code = "<html><body><table>{}</table></body></html>".format(html_code)
     return html_code
 

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -212,9 +212,9 @@ def expand_list(merged, html_list):
     # Add the colspan and rowspan attributes only if necessary
     html_list[sr][sc] = ""
     if ec - sc > 0:  # Only add colspan if the column span is more than 1
-        html_list[sr][sc] += ' colspan={}'.format(ec - sc + 1)
+        html_list[sr][sc] += " colspan={}".format(ec - sc + 1)
     if er - sr > 0:  # Only add rowspan if the row span is more than 1
-        html_list[sr][sc] += ' rowspan={}'.format(er - sr + 1)
+        html_list[sr][sc] += " rowspan={}".format(er - sr + 1)
     return html_list
 
 
@@ -259,7 +259,7 @@ def rebuild_html_from_ppstructure_label(label_info):
             cell = "".join(cell)
             html_code.insert(i + 1, cell)
     html_code = "".join(html_code)
-    html_code = re.sub(r'(colspan|rowspan)="(\d+)"', r'\1=\2', html_code)
+    html_code = re.sub(r'(colspan|rowspan)="(\d+)"', r"\1=\2", html_code)
     html_code = "<html><body><table>{}</table></body></html>".format(html_code)
     return html_code
 


### PR DESCRIPTION
## 解决导出表格标注时遇到的通用问题

### 可复现软件版本
- PPOCRLabel v2.1.8

### 可复现问题资源
![56](https://github.com/user-attachments/assets/12997dd6-a290-4c5a-9ea3-911cbc9d4ec8)

### 问题1：导出表格标注时添加colspan和rowspan时的异常
- 问题描述
导出表格标注时，从Excel中获取标注表格的格式，对合并列或是合并行添加colspan和rowspan时判断条件错误。
例如：一个5行、5列的表格，第一行的第2列和第3列是合并的，第4列和第5列是合并的，代码中for循环构建出来的html_list 列表第一行是不对的。
```shell
错误结果："<tr>", "<td>", "</td>", "<td", ">", "</td>", "<td>", "</td>", "<td", ">", "</td>", "<td>", "</td>", "</tr>"

期望结果："<tr>", "<td>", "</td>", "<td", " colspan=\"2\"", ">", "</td>", "<td", " colspan=\"2\"", ">", "</td>", "</tr>"
```
```shell
当前代码：
html_list[sr][sc] = ""
    if ec - sc > 1:
        html_list[sr][sc] += " colspan={}".format(ec - sc)
    if er - sr > 1:
        html_list[sr][sc] += " rowspan={}".format(er - sr)

修改后代码：
html_list[sr][sc] = ""
    if ec - sc > 0:  # Only add colspan if the column span is more than 1
        html_list[sr][sc] += ' colspan={}'.format(ec - sc + 1)
    if er - sr > 0:  # Only add rowspan if the row span is more than 1
        html_list[sr][sc] += ' rowspan={}'.format(er - sr + 1)
```
- 验证
代码修改后经过60张表格图片导出标注的验证，所有图片均符合模型训练要求并完成模型训练。

### 问题2：导出的gt文件中gt属性中html标签合规的问题
- 问题描述
在rebuild_html_from_ppstructure_label方法中，生成的新html，colspan和rowspan的值不符合html直接显示标准。colspan和rowspan的值必须是数字，html的内容是在convert_token生成的，生成时colspan和rowspan的值均是字符串（应该是为了模型训练）。
```shell
错误结果： <tbody><tr><td></td><td colspan=“2”>本集团</td><td colspan=“2”>本银行</td></tr><tr><td></td><td>2023年</td><td>2022年</td><td>2023年</td><td>2022年</td></tr><tr><td></td><td>12月31日</td><td>12月31日</td><td>12月31日</td><td>12月31日</td></tr><tr><td></td><td></td><td></td><td></td><td></td></tr><tr><td>股权投资</td><td>6,489</td><td>7,131</td><td>6,081</td><td>6,726</td></tr></tbody>

期望结果： <tbody><tr><td></td><td colspan=2>本集团</td><td colspan=2>本银行</td></tr><tr><td></td><td>2023年</td><td>2022年</td><td>2023年</td><td>2022年</td></tr><tr><td></td><td>12月31日</td><td>12月31日</td><td>12月31日</td><td>12月31日</td></tr><tr><td></td><td></td><td></td><td></td><td></td></tr><tr><td>股权投资</td><td>6,489</td><td>7,131</td><td>6,081</td><td>6,726</td></tr></tbody>
```
```shell
当前代码：
    html_code = "".join(html_code)
    html_code = "<html><body><table>{}</table></body></html>".format(html_code)

修改后代码：
    html_code = "".join(html_code)
    html_code = re.sub(r'(colspan|rowspan)="(\d+)"', r'\1=\2', html_code)
    html_code = "<html><body><table>{}</table></body></html>".format(html_code)
```
- 验证
经过60张图片导出标注，将gt.txt中的gt属性拷贝到后缀为html的文件中，直接打开，在浏览器可以看到还原的表格，全部正确。
