### PR TITLE
Add note about `--lang en` in README  

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ For more software version requirements, please refer to the instructions in [Ins
 
 PPOCRLabel can be started in two ways: whl package and Python script. The whl package form is more convenient to start, and the python script to start is convenient for secondary development.
 
+> Note: By default, PPOCRLabel starts with a **Chinese** UI (`--lang ch`). To switch to **English**, you need to launch the application with the `--lang en` parameter.
+
 #### Windows
 
 ```bash


### PR DESCRIPTION
Hi, 

I added a note to the README on how to start PPOCRLabel with an English UI, as this information was missing. By default, the UI starts in Chinese unless the `--lang en` parameter is used. This should help new users who need an English interface.

Thanks! 🚀