### PR TITLE
Updates PaddlePaddle to stable version 3.0.0 from rc1 and pins PaddleOCR version

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -18,8 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          pip install paddlepaddle==3.0.0rc1 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
-          pip install paddleocr
+          pip install paddlepaddle==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
           pip install -e .
 
       - name: Regenerate Resources (if using PyQt)
@@ -50,8 +49,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          pip install paddlepaddle==3.0.0rc1 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
-          pip install paddleocr
+          pip install paddlepaddle==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
           pip install -e .
 
       - name: Regenerate Resources (if using PyQt)
@@ -82,8 +80,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pyinstaller
-          pip install paddlepaddle==3.0.0rc1 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
-          pip install paddleocr
+          pip install paddlepaddle==3.0.0 -i https://www.paddlepaddle.org.cn/packages/stable/cpu/
           pip install -e .
 
       - name: Install system dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "PPOCRLabel"
 dynamic = ["version"]
 dependencies = [
   "pyqt5",
-  "paddleocr",
+  "paddleocr<3.0",
   "openpyxl",
   "tqdm",
   "premailer",


### PR DESCRIPTION
This pull request updates dependencies to ensure compatibility with stable versions and introduces constraints to prevent potential issues with future releases. The most important changes include updating the PaddlePaddle version in the release workflow and adding a version constraint for PaddleOCR in the `pyproject.toml` file.

### Dependency Updates:

* [`.github/workflows/release-build.yml`](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL21-R21): Updated the PaddlePaddle dependency from `3.0.0rc1` to the stable release `3.0.0` and removed the installation of PaddleOCR in three separate job steps. [[1]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL21-R21) [[2]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL53-R52) [[3]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL85-R83)

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10): Added a version constraint for PaddleOCR (`paddleocr<3.0`) to ensure compatibility with the current project setup.