### PR TITLE
fix bug in PPOCRLabel.py

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -199,6 +199,7 @@ class MainWindow(QMainWindow):
             "lang": self.lang,
             "text_detection_model_name": "PP-OCRv5_server_det",
             "text_recognition_model_name": "PP-OCRv5_server_rec",
+            "enable_mkldnn":False,
         }
 
         if det_model_dir is not None:
@@ -210,10 +211,10 @@ class MainWindow(QMainWindow):
 
         self.ocr = PaddleOCR(**params)
         self.text_recognizer = TextRecognition(
-            model_name="PP-OCRv5_server_rec", model_dir=rec_model_dir, device=self.gpu
+            model_name="PP-OCRv5_server_rec", model_dir=rec_model_dir, device=self.gpu, enable_mkldnn = False
         )
         self.text_detector = TextDetection(
-            model_name="PP-OCRv5_server_det", model_dir=det_model_dir, device=self.gpu
+            model_name="PP-OCRv5_server_det", model_dir=det_model_dir, device=self.gpu, enable_mkldnn = False
         )
         self.table_ocr = PPStructureV3(
             use_doc_orientation_classify=False,
@@ -224,6 +225,7 @@ class MainWindow(QMainWindow):
             use_chart_recognition=False,
             use_region_detection=False,
             device=self.gpu,
+            enable_mkldnn = False,
         )
 
         if os.path.exists("./data/paddle.png"):
@@ -3148,7 +3150,12 @@ class MainWindow(QMainWindow):
             )
             QMessageBox.information(self, "Information", msg)
             # create an empty excel
-            tablepyxl.document_to_xl("", excel_path)
+            try:
+                tablepyxl.document_to_xl("", excel_path)
+            except AttributeError:  # 如果 tablepyxl 报错，改用 openpyxl
+                import openpyxl
+                wb = openpyxl.Workbook()
+                wb.save(excel_path)
             return
 
         # automatically open excel annotation file


### PR DESCRIPTION
When clicking on “Table Recognition,” if no table is detected, an empty table is created, but this triggers an error. The following is the error message:

Traceback (most recent call last):
  File "/Users/guoshengjian/PPOCRLabel/PPOCRLabel.py", line 3153, in TableRecognition
    tablepyxl.document_to_xl("", excel_path)
  File "/Users/guoshengjian/PPOCRLabel/tablepyxl/tablepyxl.py", line 118, in document_to_xl
    wb = document_to_workbook(doc, base_url=base_url)
  File "/Users/guoshengjian/PPOCRLabel/tablepyxl/tablepyxl.py", line 104, in document_to_workbook
    ).transform()
  File "/opt/miniconda3/envs/Label/lib/python3.10/site-packages/premailer/premailer.py", line 353, in transform
    tree = etree.fromstring(stripped, parser).getroottree()
AttributeError: 'NoneType' object has no attribute 'getroottree'
zsh: abort      python PPOCRLabel.py

The error occurs because the document_to_xl() function is being called with an empty string (""), which leads to a None value being processed by premailer, resulting in the AttributeError.