### PR TITLE
[Bug] Fix drawText bug

### DIFF
--- a/libs/shape.py
+++ b/libs/shape.py
@@ -184,7 +184,7 @@ class Shape(object):
                         self.label = ""
                     if min_y < MIN_Y_LABEL:
                         min_y += MIN_Y_LABEL
-                    painter.drawText(min_x, min_y, self.label)
+                    painter.drawText(int(min_x), int(min_y), self.label)
 
             # Draw number at the top-right
             if self.paintIdx:


### PR DESCRIPTION
When using the label display function, an error occurs.
drawText(self, p: Union[QPointF, QPoint], s: Optional[str]): argument 1 has unexpected type 'float'
  drawText(self, rectangle: QRectF, flags: int, text: Optional[str]): argument 1 has unexpected type 'float'
  drawText(self, rectangle: QRect, flags: int, text: Optional[str]): argument 1 has unexpected type 'float'
  drawText(self, rectangle: QRectF, text: Optional[str], option: QTextOption = QTextOption()): argument 1 has unexpected type 'float'
  drawText(self, p: QPoint, s: Optional[str]): argument 1 has unexpected type 'float'
  drawText(self, x: int, y: int, width: int, height: int, flags: int, text: Optional[str]): argument 1 has unexpected type 'float'
  drawText(self, x: int, y: int, s: Optional[str]): argument 1 has unexpected type 'float'