### PR TITLE
[Fix] Update `cv2.imdecode` to use `cv2.IMREAD_COLOR` for consistent

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -2137,7 +2137,9 @@ class MainWindow(QMainWindow):
 
         if unicodeFilePath and os.path.exists(unicodeFilePath):
             self.canvas.verified = False
-            cvimg = cv2.imdecode(np.fromfile(unicodeFilePath, dtype=np.uint8), 1)
+            cvimg = cv2.imdecode(
+                np.fromfile(unicodeFilePath, dtype=np.uint8), cv2.IMREAD_COLOR
+            )
             height, width, depth = cvimg.shape
             cvimg = cv2.cvtColor(cvimg, cv2.COLOR_BGR2RGB)
             image = QImage(
@@ -2939,7 +2941,7 @@ class MainWindow(QMainWindow):
         self.init_key_list(self.Cachelabel)
 
     def reRecognition(self):
-        img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), 1)
+        img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), cv2.IMREAD_COLOR)
         if self.canvas.shapes:
             self.result_dic = []
             self.result_dic_locked = (
@@ -3023,7 +3025,7 @@ class MainWindow(QMainWindow):
             QMessageBox.information(self, "Information", "Draw a box!")
 
     def singleRerecognition(self):
-        img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), 1)
+        img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), cv2.IMREAD_COLOR)
         for shape in self.canvas.selectedShapes:
             box = [[int(p.x()), int(p.y())] for p in shape.points]
             if len(box) > 4:
@@ -3495,7 +3497,9 @@ class MainWindow(QMainWindow):
                 idx = self.getImglabelidx(key)
                 try:
                     img_path = os.path.dirname(base_dir) + "/" + key
-                    img = cv2.imdecode(np.fromfile(img_path, dtype=np.uint8), -1)
+                    img = cv2.imdecode(
+                        np.fromfile(img_path, dtype=np.uint8), cv2.IMREAD_COLOR
+                    )
                     for i, label in enumerate(self.PPlabel[idx]):
                         if label["difficult"]:
                             continue
@@ -3645,7 +3649,7 @@ class MainWindow(QMainWindow):
             self.actions.save.setEnabled(True)
 
     def expandSelectedShape(self):
-        img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), 1)
+        img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), cv2.IMREAD_COLOR)
         for shape in self.canvas.selectedShapes:
             box = [[int(p.x()), int(p.y())] for p in shape.points]
             if len(box) > 4:

--- a/libs/autoDialog.py
+++ b/libs/autoDialog.py
@@ -42,7 +42,7 @@ class Worker(QThread):
                     self.listValue.emit(img_path)
                     if self.model == "paddle":
                         h, w, _ = cv2.imdecode(
-                            np.fromfile(img_path, dtype=np.uint8), 1
+                            np.fromfile(img_path, dtype=np.uint8), cv2.IMREAD_COLOR
                         ).shape
                         if h > 32 and w > 32:
                             result = self.ocr.predict(img_path)[0]


### PR DESCRIPTION
This pull request updates multiple methods across the `PPOCRLabel.py` and `libs/autoDialog.py` files to improve clarity and maintainability by replacing the hardcoded `1` parameter in `cv2.imdecode` with the more descriptive `cv2.IMREAD_COLOR`. This change ensures better readability and aligns with OpenCV's standard practices.

### Updates to `cv2.imdecode` usage:

* Replaced the `1` parameter with `cv2.IMREAD_COLOR` in the `loadFile` method to improve code clarity and consistency. (`PPOCRLabel.py`, [PPOCRLabel.pyL2140-R2142](diffhunk://#diff-8776870c37af691ef6532d16681758c9023669ef2d5814c2ae5aa961dea769e4L2140-R2142))
* Updated the `autoRecognition`, `reRecognition`, `singleRerecognition`, and `expandSelectedShape` methods to use `cv2.IMREAD_COLOR` for decoding images. (`PPOCRLabel.py`, [[1]](diffhunk://#diff-8776870c37af691ef6532d16681758c9023669ef2d5814c2ae5aa961dea769e4L2942-R2944) [[2]](diffhunk://#diff-8776870c37af691ef6532d16681758c9023669ef2d5814c2ae5aa961dea769e4L3026-R3028) [[3]](diffhunk://#diff-8776870c37af691ef6532d16681758c9023669ef2d5814c2ae5aa961dea769e4L3648-R3652)
* Modified the `saveRecResult` method to decode images using `cv2.IMREAD_COLOR` for consistency with other methods. (`PPOCRLabel.py`, [PPOCRLabel.pyL3498-R3502](diffhunk://#diff-8776870c37af691ef6532d16681758c9023669ef2d5814c2ae5aa961dea769e4L3498-R3502))
* Applied the same replacement in the `run` method of `libs/autoDialog.py` to maintain uniformity across the codebase. (`libs/autoDialog.py`, [libs/autoDialog.pyL45-R45](diffhunk://#diff-e2be86fe170286e4841857fd455dc003a6e7fc66255a49f72725d651ee5e34b6L45-R45))