### PR TITLE
[Fix] Remove confirmation status and "done" icon after image rotation

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -1399,6 +1399,19 @@ class MainWindow(QMainWindow):
         ext = os.path.splitext(filename)[1]
         cv2.imencode(ext, pix)[1].tofile(filename)
         self.canvas.update()
+
+        # Remove confirmation status after rotation
+        img_idx = self.getImglabelidx(filename)
+        if img_idx in self.fileStatedict:
+            self.fileStatedict.pop(img_idx)
+
+        # Remove the "done" icon from the file list
+        if filename in self.mImgList:
+            currIndex = self.mImgList.index(filename)
+            item = self.fileListWidget.item(currIndex)
+            if item:
+                item.setIcon(QIcon())
+
         self.loadFile(filename)
 
     def rotateImgWarn(self):


### PR DESCRIPTION
This pull request updates the image rotation functionality to ensure that after rotating an image, its confirmation status is cleared and the "done" icon is removed from the file list. This helps prevent confusion by indicating that the image needs to be reviewed again after modification.

**Image rotation and status reset:**

* After rotating an image in `rotateImg`, the confirmation status is removed from `fileStatedict` for the affected image, ensuring that users are prompted to re-confirm the image.
* The "done" icon is cleared from the file list for the rotated image, visually indicating that the image is no longer confirmed.