### PR TITLE
Improve image reading with buffer validation

### DIFF
--- a/libs/autoDialog.py
+++ b/libs/autoDialog.py
@@ -44,7 +44,7 @@ class Worker(QThread):
                         buf = np.fromfile(img_path, dtype=np.uint8)
                         if buf.size == 0:
                             logger.warning(
-                                "Failed to read the image's buffer. The file may be corrupted or in an unsupported format : %s", 
+                                "Failed to read the image's buffer. The file may be corrupted or in an unsupported format: %s",
                                 img_path,
                             )
                             self.result_dic = None


### PR DESCRIPTION
Currently, if the image set contains even a single corrupted or unreadable file, the entire application crashes during auto-detection/auto-recognition. This patch introduces a validation step on the image buffer before calling `cv2.imdecode()`. If the buffer is empty or invalid, the application logs a warning and skips the file instead of raising an exception. This prevents the full process from terminating unexpectedly and avoids losing progress when processing large batches of images.

Since this problem could occur in multiple occasions, consider building a custom utility to replace all the calls to `cv2.imdecode()` to implement a buffer validation and prevent crashing in case the image set contains corrupted or unusable images:

```python
def imread(path):
    buf = np.fromfile(path, dtype=np.uint8)
    if buf.size == 0:
        logger.warning(
                "Failed to read the image's buffer. The file may be corrupted or in an unsupported format : %s", 
                img_path,
        )
        self.result_dic = None
        return None
    return cv2.imdecode(buf, cv2.IMREAD_COLOR)
```