### PR TITLE
feat: Tab/Shift+Tab navigation and F2 inline edit for label list

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -2113,6 +2113,11 @@ class MainWindow(QMainWindow):
                 selected_shapes.append(self.itemsToShapes[item])
             if selected_shapes:
                 self.canvas.selectShapes(selected_shapes)
+                score = selected_shapes[0].score
+                if score is not None:
+                    self.confidenceLabel.setText(
+                        f"Threshold: {self.confidenceSlider.value() / 100:.2f}   |   Selected: {score:.2f}"
+                    )
             else:
                 self.canvas.deSelectShape()
 

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -401,6 +401,7 @@ class MainWindow(QMainWindow):
         labelListContainer.setLayout(listLayout)
         self.labelList.itemSelectionChanged.connect(self.labelSelectionChanged)
         self.labelList.clicked.connect(self.labelList.item_clicked)
+        self.labelList.navigated.connect(self.focusAndZoom)
 
         # Connect to itemChanged to detect checkbox changes.
         self.labelList.itemChanged.connect(self.labelItemChanged)

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -22,6 +22,7 @@ import platform
 import signal
 import subprocess
 import sys
+import torch  # noqa: F401 — keeps torch DLLs loaded for PaddlePaddle on Windows
 from functools import partial
 from PyQt5.QtWidgets import QShortcut
 from PyQt5.QtGui import QKeySequence

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -1970,7 +1970,9 @@ class MainWindow(QMainWindow):
     def loadLabels(self, shapes):
         s = []
         shape_index = 0
-        for label, points, line_color, key_cls in shapes:
+        for item in shapes:
+            label, points, line_color, key_cls = item[:4]
+            score = item[4] if len(item) > 4 else None
             shape = Shape(
                 label=label,
                 line_color=line_color,
@@ -1986,7 +1988,7 @@ class MainWindow(QMainWindow):
                 shape.addPoint(QPointF(x, y))
             shape.idx = shape_index
             shape_index += 1
-            # shape.locked = False
+            shape.score = score
             shape.close()
             s.append(shape)
 
@@ -2035,13 +2037,16 @@ class MainWindow(QMainWindow):
 
         def format_shape(s):
             # print('s in saveLabels is ',s)
-            return dict(
+            d = dict(
                 label=s.label,  # str
                 line_color=s.line_color.getRgb(),
                 fill_color=s.fill_color.getRgb(),
                 points=[(int(p.x()), int(p.y())) for p in s.points],  # QPonitF
                 key_cls=s.key_cls,
-            )  # bool
+            )
+            if s.score is not None:
+                d["score"] = round(float(s.score), 4)
+            return d
 
         if mode == "Auto":
             shapes = []
@@ -2053,7 +2058,7 @@ class MainWindow(QMainWindow):
             ]
         # Can add different annotation formats here
         for box in self.result_dic:
-            trans_dic = {"label": box[1][0], "points": box[0]}
+            trans_dic = {"label": box[1][0], "points": box[0], "score": box[1][1]}
             if self.kie_mode:
                 if len(box) == 3:
                     trans_dic.update({"key_cls": box[2]})
@@ -2071,6 +2076,8 @@ class MainWindow(QMainWindow):
                     "points": box["points"],
                     "difficult": False,
                 }
+                if box.get("score") is not None:
+                    trans_dict["score"] = round(float(box["score"]), 4)
                 if self.kie_mode:
                     trans_dict.update({"key_cls": box["key_cls"]})
                 trans_dic.append(trans_dict)
@@ -2494,6 +2501,7 @@ class MainWindow(QMainWindow):
                         [[s[0] * width, s[1] * height] for s in box["ratio"]],
                         DEFAULT_LOCK_COLOR,
                         key_cls,
+                        None,
                     )
                 )
             else:
@@ -2503,6 +2511,7 @@ class MainWindow(QMainWindow):
                         [[s[0] * width, s[1] * height] for s in box["ratio"]],
                         DEFAULT_LOCK_COLOR,
                         key_cls,
+                        None,
                     )
                 )
         if img_idx in self.PPlabel.keys():
@@ -2514,12 +2523,14 @@ class MainWindow(QMainWindow):
                         box["points"],
                         None,
                         key_cls,
+                        box.get("score"),
                     )
                 )
 
         if shapes:
             self.loadLabels(shapes)
             self.canvas.verified = False
+            self.applyConfidenceFilter()
 
     def validFilestate(self, filePath):
         if filePath in self.fileStatedict.keys() and self.fileStatedict[filePath] == 1:

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -1182,12 +1182,6 @@ class MainWindow(QMainWindow):
         self.autoSaveUnsavedChangesOption.triggered.connect(self.autoSaveFunc)
 
         QShortcut(
-            QKeySequence(Qt.Key_Tab), self, activated=lambda: self._navigateLabel(+1)
-        )
-        QShortcut(
-            QKeySequence("Shift+Tab"), self, activated=lambda: self._navigateLabel(-1)
-        )
-        QShortcut(
             QKeySequence(Qt.Key_F2),
             self,
             activated=lambda: (
@@ -1347,12 +1341,6 @@ class MainWindow(QMainWindow):
         if event.key() == Qt.Key_Control:
             # Draw rectangle if Ctrl is pressed
             self.canvas.setDrawingShapeToSquare(True)
-        elif event.key() == Qt.Key_Tab and not event.modifiers() & Qt.ShiftModifier:
-            self._navigateLabel(+1)
-            event.accept()
-        elif event.key() == Qt.Key_Tab and event.modifiers() & Qt.ShiftModifier:
-            self._navigateLabel(-1)
-            event.accept()
         elif event.key() in (Qt.Key_F2, Qt.Key_Return, Qt.Key_Enter):
             if self.currentItem() is not None:
                 self.labelList.activate_edit()

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -1362,7 +1362,8 @@ class MainWindow(QMainWindow):
         self.labelList.setCurrentRow(next_row)
         self.labelList.scrollToItem(self.labelList.item(next_row))
         self.labelSelectionChanged()
-    
+        self.focusAndZoom()        # ← Ctrl+G'nin yaptığı
+        self.labelList.activate_edit()  # ← F2'nin yaptığı
 
     def noShapes(self):
         return not self.itemsToShapes

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -22,7 +22,11 @@ import platform
 import signal
 import subprocess
 import sys
+import torch
+
 from functools import partial
+from PyQt5.QtWidgets import QShortcut
+from PyQt5.QtGui import QKeySequence
 
 import openpyxl
 import cv2
@@ -1178,6 +1182,10 @@ class MainWindow(QMainWindow):
         )
         self.displayIndexOption.setChecked(settings.get(SETTING_PAINT_INDEX, False))
         self.autoSaveUnsavedChangesOption.triggered.connect(self.autoSaveFunc)
+        
+        QShortcut(QKeySequence(Qt.Key_Tab), self, activated=lambda: self._navigateLabel(+1))
+        QShortcut(QKeySequence("Shift+Tab"), self, activated=lambda: self._navigateLabel(-1))
+        QShortcut(QKeySequence(Qt.Key_F2), self, activated=lambda: self.labelList.activate_edit() if self.currentItem() else None)
 
         addActions(
             self.menus.file,
@@ -1331,6 +1339,30 @@ class MainWindow(QMainWindow):
         if event.key() == Qt.Key_Control:
             # Draw rectangle if Ctrl is pressed
             self.canvas.setDrawingShapeToSquare(True)
+        elif event.key() == Qt.Key_Tab and not event.modifiers() & Qt.ShiftModifier:
+            self._navigateLabel(+1)
+            event.accept()
+        elif event.key() == Qt.Key_Tab and event.modifiers() & Qt.ShiftModifier:
+            self._navigateLabel(-1)
+            event.accept()
+        elif event.key() in (Qt.Key_F2, Qt.Key_Return, Qt.Key_Enter):
+            if self.currentItem() is not None:
+                self.labelList.activate_edit()
+                event.accept()
+
+    def _navigateLabel(self, direction):
+        count = self.labelList.count()
+        if count == 0:
+            return
+        current = self.labelList.currentRow()
+        if current < 0:
+            next_row = 0 if direction > 0 else count - 1
+        else:
+            next_row = (current + direction) % count
+        self.labelList.setCurrentRow(next_row)
+        self.labelList.scrollToItem(self.labelList.item(next_row))
+        self.labelSelectionChanged()
+    
 
     def noShapes(self):
         return not self.itemsToShapes

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -22,8 +22,6 @@ import platform
 import signal
 import subprocess
 import sys
-import torch
-
 from functools import partial
 from PyQt5.QtWidgets import QShortcut
 from PyQt5.QtGui import QKeySequence
@@ -1182,10 +1180,20 @@ class MainWindow(QMainWindow):
         )
         self.displayIndexOption.setChecked(settings.get(SETTING_PAINT_INDEX, False))
         self.autoSaveUnsavedChangesOption.triggered.connect(self.autoSaveFunc)
-        
-        QShortcut(QKeySequence(Qt.Key_Tab), self, activated=lambda: self._navigateLabel(+1))
-        QShortcut(QKeySequence("Shift+Tab"), self, activated=lambda: self._navigateLabel(-1))
-        QShortcut(QKeySequence(Qt.Key_F2), self, activated=lambda: self.labelList.activate_edit() if self.currentItem() else None)
+
+        QShortcut(
+            QKeySequence(Qt.Key_Tab), self, activated=lambda: self._navigateLabel(+1)
+        )
+        QShortcut(
+            QKeySequence("Shift+Tab"), self, activated=lambda: self._navigateLabel(-1)
+        )
+        QShortcut(
+            QKeySequence(Qt.Key_F2),
+            self,
+            activated=lambda: (
+                self.labelList.activate_edit() if self.currentItem() else None
+            ),
+        )
 
         addActions(
             self.menus.file,
@@ -1361,9 +1369,7 @@ class MainWindow(QMainWindow):
             next_row = (current + direction) % count
         self.labelList.setCurrentRow(next_row)
         self.labelList.scrollToItem(self.labelList.item(next_row))
-        self.labelSelectionChanged()
-        self.focusAndZoom()        # ← Ctrl+G'nin yaptığı
-        self.labelList.activate_edit()  # ← F2'nin yaptığı
+        self.focusAndZoom()
 
     def noShapes(self):
         return not self.itemsToShapes
@@ -2621,7 +2627,9 @@ class MainWindow(QMainWindow):
 
         else:
             if self.lang == "ch":
-                self.msgBox.warning(self, "提示", "\n 原文件夹已不存在,请从新选择数据集路径!")
+                self.msgBox.warning(
+                    self, "提示", "\n 原文件夹已不存在,请从新选择数据集路径!"
+                )
             else:
                 self.msgBox.warning(
                     self,

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -484,6 +484,35 @@ class MainWindow(QMainWindow):
         self.imageSliderDock.setAttribute(Qt.WA_TranslucentBackground)
         self.addDockWidget(Qt.RightDockWidgetArea, self.imageSliderDock)
 
+        #  ================== Confidence Filter ==================
+        self.confidenceSlider = QSlider(Qt.Horizontal)
+        self.confidenceSlider.setMinimum(0)
+        self.confidenceSlider.setMaximum(100)
+        self.confidenceSlider.setValue(100)
+        self.confidenceSlider.setSingleStep(1)
+        self.confidenceSlider.setToolTip(
+            "Show only boxes with confidence BELOW this threshold"
+        )
+        self.confidenceSlider.valueChanged.connect(self.onConfidenceFilterChanged)
+
+        self.confidenceLabel = QLabel("Threshold: 1.00  (show all)")
+        self.confidenceLabel.setAlignment(Qt.AlignCenter)
+
+        confWidget = QWidget()
+        confLayout = QVBoxLayout()
+        confLayout.setContentsMargins(4, 4, 4, 4)
+        confLayout.addWidget(self.confidenceLabel)
+        confLayout.addWidget(self.confidenceSlider)
+        confWidget.setLayout(confLayout)
+
+        self.confidenceFilterDock = QDockWidget("Confidence Filter", self)
+        self.confidenceFilterDock.setObjectName("ConfidenceFilter")
+        self.confidenceFilterDock.setWidget(confWidget)
+        self.confidenceFilterDock.setFeatures(
+            QDockWidget.DockWidgetFloatable | QDockWidget.DockWidgetClosable
+        )
+        self.addDockWidget(Qt.RightDockWidgetArea, self.confidenceFilterDock)
+
         self.zoomWidget = ZoomWidget()
         self.colorDialog = ColorDialog(parent=self)
         self.zoomWidgetValue = self.zoomWidget.value()
@@ -1358,6 +1387,23 @@ class MainWindow(QMainWindow):
         self.labelList.setCurrentRow(next_row)
         self.labelList.scrollToItem(self.labelList.item(next_row))
         self.focusAndZoom()
+
+    def onConfidenceFilterChanged(self, value):
+        threshold = value / 100.0
+        if value == 100:
+            self.confidenceLabel.setText("Threshold: 1.00  (show all)")
+        else:
+            self.confidenceLabel.setText(f"Threshold: {threshold:.2f}")
+        self.applyConfidenceFilter()
+
+    def applyConfidenceFilter(self):
+        threshold = self.confidenceSlider.value() / 100.0
+        for shape in self.canvas.shapes:
+            if shape.score is None:
+                self.canvas.setShapeVisible(shape, True)
+            else:
+                self.canvas.setShapeVisible(shape, shape.score < threshold)
+        self.canvas.update()
 
     def noShapes(self):
         return not self.itemsToShapes
@@ -3277,6 +3323,9 @@ class MainWindow(QMainWindow):
         self.loadFile(self.filePath, isAdjustScale=False)
         self.canvas.isInTheSameImage = False
         self.setDirty()
+        for shape, box in zip(self.canvas.shapes, self.result_dic):
+            shape.score = box[1][1]
+        self.applyConfidenceFilter()
 
     def singleRerecognition(self):
         img = cv2.imdecode(np.fromfile(self.filePath, dtype=np.uint8), cv2.IMREAD_COLOR)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -3,6 +3,7 @@
 from PyQt5.QtCore import QModelIndex
 from PyQt5.QtWidgets import QListWidget
 
+
 class EditInList(QListWidget):
     def __init__(self):
         super(EditInList, self).__init__()
@@ -38,15 +39,11 @@ class EditInList(QListWidget):
         self.edited_item = item
         self.openPersistentEditor(item)
         self.editItem(item)
-    
+
     def keyPressEvent(self, event) -> None:
-        # close edit
-        if event.key() in [16777220, 16777221, 16777217]:  # Enter / Return / Tab
+        if event.key() in [16777220, 16777221]:  # Enter / Return
             for i in range(self.count()):
                 self.closePersistentEditor(self.item(i))
-            # bir sonraki satıra geç ve editörü aç
-            next_row = self.currentRow() + 1
-            if next_row < self.count():
-                self.setCurrentRow(next_row)
-                self.scrollToItem(self.item(next_row))
-                self.activate_edit()
+            event.accept()
+            return
+        super().keyPressEvent(event)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -39,16 +39,28 @@ class EditInList(QListWidget):
         self.edited_item = item
         self.openPersistentEditor(item)
         self.editItem(item)
-        # Intercept Tab/Shift+Tab inside the editor widget before QLineEdit consumes them
         editor = self.indexWidget(self.indexFromItem(item))
         if editor is not None:
             editor.installEventFilter(self)
 
+    def _commit_and_close(self):
+        """Commit current editor value to the model, then close all editors."""
+        if self.edited_item is not None:
+            editor = self.indexWidget(self.indexFromItem(self.edited_item))
+            if editor is not None:
+                self.commitData(editor)
+        for i in range(self.count()):
+            self.closePersistentEditor(self.item(i))
+        self.edited_item = None
+
     def eventFilter(self, obj, event):
+        """Intercept Tab/Shift+Tab inside the persistent editor (QLineEdit).
+        QShortcut would fire before the editor receives the key, so Tab
+        navigation is handled here instead of via QShortcut."""
         if event.type() == QEvent.KeyPress:
             key = event.key()
-            if key == 16777217:  # Tab: save, move to next, open editor
-                self._close_editors()
+            if key == 16777217:  # Tab: commit, move to next, open editor
+                self._commit_and_close()
                 next_row = self.currentRow() + 1
                 if next_row < self.count():
                     self.setCurrentRow(next_row)
@@ -57,8 +69,8 @@ class EditInList(QListWidget):
                 return True
             if (
                 key == 16777218
-            ):  # Shift+Tab / Backtab: save, move to previous, open editor
-                self._close_editors()
+            ):  # Shift+Tab / Backtab: commit, move to previous, open editor
+                self._commit_and_close()
                 prev_row = self.currentRow() - 1
                 if prev_row >= 0:
                     self.setCurrentRow(prev_row)
@@ -67,23 +79,28 @@ class EditInList(QListWidget):
                 return True
         return super().eventFilter(obj, event)
 
-    def _close_editors(self):
-        if self.edited_item is not None:
-            editor = self.indexWidget(self.indexFromItem(self.edited_item))
-            if editor is not None:
-                self.commitData(editor)  # flush editor value to model before closing
-        for i in range(self.count()):
-            self.closePersistentEditor(self.item(i))
-        self.edited_item = None
-
     def keyPressEvent(self, event) -> None:
         key = event.key()
-        if key in (16777220, 16777221):  # Enter / Return: save and move to next
-            self._close_editors()
+        if key in (16777220, 16777221):  # Enter / Return: commit and move to next
+            self._commit_and_close()
             next_row = self.currentRow() + 1
             if next_row < self.count():
                 self.setCurrentRow(next_row)
                 self.scrollToItem(self.item(next_row))
+            event.accept()
+            return
+        if key == 16777217:  # Tab (no editor open): just navigate
+            next_row = self.currentRow() + 1
+            if next_row < self.count():
+                self.setCurrentRow(next_row)
+                self.scrollToItem(self.item(next_row))
+            event.accept()
+            return
+        if key == 16777218:  # Shift+Tab (no editor open): just navigate back
+            prev_row = self.currentRow() - 1
+            if prev_row >= 0:
+                self.setCurrentRow(prev_row)
+                self.scrollToItem(self.item(prev_row))
             event.accept()
             return
         super().keyPressEvent(event)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -53,19 +53,19 @@ class EditInList(QListWidget):
             QApplication.instance().removeEventFilter(self)
             self._app_filter_active = False
 
-    def _editor_text(self):
-        """Return current text from whichever QLineEdit child is visible."""
-        for child in self.findChildren(QLineEdit):
-            if child.isVisible():
-                return child.text()
-        return None
-
     def _save_and_close(self):
         """Write editor text back to the item, then close all editors."""
         if self.edited_item is not None:
-            text = self._editor_text()
-            if text is not None:
-                self.edited_item.setText(text)
+            # Use the currently focused widget — guaranteed to be what user typed in
+            focused = QApplication.focusWidget()
+            if isinstance(focused, QLineEdit):
+                self.edited_item.setText(focused.text())
+            else:
+                # Fallback: search visible QLineEdit children
+                for child in self.findChildren(QLineEdit):
+                    if child.isVisible():
+                        self.edited_item.setText(child.text())
+                        break
         self._remove_app_filter()
         for i in range(self.count()):
             self.closePersistentEditor(self.item(i))

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -40,10 +40,37 @@ class EditInList(QListWidget):
         self.openPersistentEditor(item)
         self.editItem(item)
 
+    def _close_editors(self):
+        for i in range(self.count()):
+            self.closePersistentEditor(self.item(i))
+        self.edited_item = None
+
     def keyPressEvent(self, event) -> None:
-        if event.key() in [16777220, 16777221]:  # Enter / Return
-            for i in range(self.count()):
-                self.closePersistentEditor(self.item(i))
+        key = event.key()
+        if key in (16777220, 16777221):  # Enter / Return: save and move to next
+            self._close_editors()
+            next_row = self.currentRow() + 1
+            if next_row < self.count():
+                self.setCurrentRow(next_row)
+                self.scrollToItem(self.item(next_row))
+            event.accept()
+            return
+        if key == 16777217:  # Tab: save, move to next, open editor
+            self._close_editors()
+            next_row = self.currentRow() + 1
+            if next_row < self.count():
+                self.setCurrentRow(next_row)
+                self.scrollToItem(self.item(next_row))
+                self.activate_edit()
+            event.accept()
+            return
+        if key == 16777218:  # Shift+Tab / Backtab: save, move to previous, open editor
+            self._close_editors()
+            prev_row = self.currentRow() - 1
+            if prev_row >= 0:
+                self.setCurrentRow(prev_row)
+                self.scrollToItem(self.item(prev_row))
+                self.activate_edit()
             event.accept()
             return
         super().keyPressEvent(event)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -3,7 +3,6 @@
 from PyQt5.QtCore import QModelIndex
 from PyQt5.QtWidgets import QListWidget
 
-
 class EditInList(QListWidget):
     def __init__(self):
         super(EditInList, self).__init__()
@@ -42,7 +41,7 @@ class EditInList(QListWidget):
     
     def keyPressEvent(self, event) -> None:
         # close edit
-        if event.key() in [16777220, 16777221]:  # Enter / Return
+        if event.key() in [16777220, 16777221, 16777217]:  # Enter / Return / Tab
             for i in range(self.count()):
                 self.closePersistentEditor(self.item(i))
             # bir sonraki satıra geç ve editörü aç

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -68,6 +68,10 @@ class EditInList(QListWidget):
         return super().eventFilter(obj, event)
 
     def _close_editors(self):
+        if self.edited_item is not None:
+            editor = self.indexWidget(self.indexFromItem(self.edited_item))
+            if editor is not None:
+                self.commitData(editor)  # flush editor value to model before closing
         for i in range(self.count()):
             self.closePersistentEditor(self.item(i))
         self.edited_item = None

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -1,6 +1,6 @@
 # !/usr/bin/env python
 # -*- coding: utf-8 -*-
-from PyQt5.QtCore import QModelIndex
+from PyQt5.QtCore import QEvent, QModelIndex
 from PyQt5.QtWidgets import QListWidget
 
 
@@ -39,6 +39,33 @@ class EditInList(QListWidget):
         self.edited_item = item
         self.openPersistentEditor(item)
         self.editItem(item)
+        # Intercept Tab/Shift+Tab inside the editor widget before QLineEdit consumes them
+        editor = self.indexWidget(self.indexFromItem(item))
+        if editor is not None:
+            editor.installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.KeyPress:
+            key = event.key()
+            if key == 16777217:  # Tab: save, move to next, open editor
+                self._close_editors()
+                next_row = self.currentRow() + 1
+                if next_row < self.count():
+                    self.setCurrentRow(next_row)
+                    self.scrollToItem(self.item(next_row))
+                    self.activate_edit()
+                return True
+            if (
+                key == 16777218
+            ):  # Shift+Tab / Backtab: save, move to previous, open editor
+                self._close_editors()
+                prev_row = self.currentRow() - 1
+                if prev_row >= 0:
+                    self.setCurrentRow(prev_row)
+                    self.scrollToItem(self.item(prev_row))
+                    self.activate_edit()
+                return True
+        return super().eventFilter(obj, event)
 
     def _close_editors(self):
         for i in range(self.count()):
@@ -53,24 +80,6 @@ class EditInList(QListWidget):
             if next_row < self.count():
                 self.setCurrentRow(next_row)
                 self.scrollToItem(self.item(next_row))
-            event.accept()
-            return
-        if key == 16777217:  # Tab: save, move to next, open editor
-            self._close_editors()
-            next_row = self.currentRow() + 1
-            if next_row < self.count():
-                self.setCurrentRow(next_row)
-                self.scrollToItem(self.item(next_row))
-                self.activate_edit()
-            event.accept()
-            return
-        if key == 16777218:  # Shift+Tab / Backtab: save, move to previous, open editor
-            self._close_editors()
-            prev_row = self.currentRow() - 1
-            if prev_row >= 0:
-                self.setCurrentRow(prev_row)
-                self.scrollToItem(self.item(prev_row))
-                self.activate_edit()
             event.accept()
             return
         super().keyPressEvent(event)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -1,10 +1,12 @@
 # !/usr/bin/env python
 # -*- coding: utf-8 -*-
-from PyQt5.QtCore import QEvent, QModelIndex
+from PyQt5.QtCore import QEvent, QModelIndex, pyqtSignal
 from PyQt5.QtWidgets import QApplication, QLineEdit, QListWidget
 
 
 class EditInList(QListWidget):
+    navigated = pyqtSignal()  # emitted after Tab/Shift+Tab navigation
+
     def __init__(self):
         super(EditInList, self).__init__()
         self.edited_item = None
@@ -84,6 +86,7 @@ class EditInList(QListWidget):
                         self.setCurrentRow(next_row)
                         self.scrollToItem(self.item(next_row))
                         self.activate_edit()
+                        self.navigated.emit()
                     return True
                 if key == 16777218:  # Shift+Tab: save, move to previous, open editor
                     self._save_and_close()
@@ -92,6 +95,7 @@ class EditInList(QListWidget):
                         self.setCurrentRow(prev_row)
                         self.scrollToItem(self.item(prev_row))
                         self.activate_edit()
+                        self.navigated.emit()
                     return True
         return False
 
@@ -110,6 +114,7 @@ class EditInList(QListWidget):
             if next_row < self.count():
                 self.setCurrentRow(next_row)
                 self.scrollToItem(self.item(next_row))
+                self.navigated.emit()
             event.accept()
             return
         if key == 16777218:  # Shift+Tab with no editor open: navigate back
@@ -117,6 +122,7 @@ class EditInList(QListWidget):
             if prev_row >= 0:
                 self.setCurrentRow(prev_row)
                 self.scrollToItem(self.item(prev_row))
+                self.navigated.emit()
             event.accept()
             return
         super().keyPressEvent(event)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -1,13 +1,14 @@
 # !/usr/bin/env python
 # -*- coding: utf-8 -*-
 from PyQt5.QtCore import QEvent, QModelIndex
-from PyQt5.QtWidgets import QListWidget
+from PyQt5.QtWidgets import QApplication, QLineEdit, QListWidget
 
 
 class EditInList(QListWidget):
     def __init__(self):
         super(EditInList, self).__init__()
         self.edited_item = None
+        self._app_filter_active = False
 
     def item_clicked(self, modelindex: QModelIndex):
         try:
@@ -19,6 +20,7 @@ class EditInList(QListWidget):
         self.edited_item = self.item(modelindex.row())
         self.openPersistentEditor(self.edited_item)
         self.editItem(self.edited_item)
+        self._install_app_filter()
 
     def mouseDoubleClickEvent(self, event):
         pass
@@ -27,7 +29,7 @@ class EditInList(QListWidget):
         pass
 
     def activate_edit(self):
-        """Open persistent editor for the currently selected item (called by F2)."""
+        """Open persistent editor for the currently selected item (called by F2/Tab)."""
         item = self.currentItem()
         if item is None:
             return
@@ -39,64 +41,78 @@ class EditInList(QListWidget):
         self.edited_item = item
         self.openPersistentEditor(item)
         self.editItem(item)
-        editor = self.indexWidget(self.indexFromItem(item))
-        if editor is not None:
-            editor.installEventFilter(self)
+        self._install_app_filter()
 
-    def _commit_and_close(self):
-        """Commit current editor value to the model, then close all editors."""
+    def _install_app_filter(self):
+        if not self._app_filter_active:
+            QApplication.instance().installEventFilter(self)
+            self._app_filter_active = True
+
+    def _remove_app_filter(self):
+        if self._app_filter_active:
+            QApplication.instance().removeEventFilter(self)
+            self._app_filter_active = False
+
+    def _editor_text(self):
+        """Return current text from whichever QLineEdit child is visible."""
+        for child in self.findChildren(QLineEdit):
+            if child.isVisible():
+                return child.text()
+        return None
+
+    def _save_and_close(self):
+        """Write editor text back to the item, then close all editors."""
         if self.edited_item is not None:
-            editor = self.indexWidget(self.indexFromItem(self.edited_item))
-            if editor is not None:
-                self.commitData(editor)
+            text = self._editor_text()
+            if text is not None:
+                self.edited_item.setText(text)
+        self._remove_app_filter()
         for i in range(self.count()):
             self.closePersistentEditor(self.item(i))
         self.edited_item = None
 
     def eventFilter(self, obj, event):
-        """Intercept Tab/Shift+Tab inside the persistent editor (QLineEdit).
-        QShortcut would fire before the editor receives the key, so Tab
-        navigation is handled here instead of via QShortcut."""
         if event.type() == QEvent.KeyPress:
-            key = event.key()
-            if key == 16777217:  # Tab: commit, move to next, open editor
-                self._commit_and_close()
-                next_row = self.currentRow() + 1
-                if next_row < self.count():
-                    self.setCurrentRow(next_row)
-                    self.scrollToItem(self.item(next_row))
-                    self.activate_edit()
-                return True
-            if (
-                key == 16777218
-            ):  # Shift+Tab / Backtab: commit, move to previous, open editor
-                self._commit_and_close()
-                prev_row = self.currentRow() - 1
-                if prev_row >= 0:
-                    self.setCurrentRow(prev_row)
-                    self.scrollToItem(self.item(prev_row))
-                    self.activate_edit()
-                return True
-        return super().eventFilter(obj, event)
+            focused = QApplication.focusWidget()
+            # Only act when the focused widget is inside this list
+            if focused is not None and self.isAncestorOf(focused):
+                key = event.key()
+                if key == 16777217:  # Tab: save, move to next, open editor
+                    self._save_and_close()
+                    next_row = self.currentRow() + 1
+                    if next_row < self.count():
+                        self.setCurrentRow(next_row)
+                        self.scrollToItem(self.item(next_row))
+                        self.activate_edit()
+                    return True
+                if key == 16777218:  # Shift+Tab: save, move to previous, open editor
+                    self._save_and_close()
+                    prev_row = self.currentRow() - 1
+                    if prev_row >= 0:
+                        self.setCurrentRow(prev_row)
+                        self.scrollToItem(self.item(prev_row))
+                        self.activate_edit()
+                    return True
+        return False
 
     def keyPressEvent(self, event) -> None:
         key = event.key()
-        if key in (16777220, 16777221):  # Enter / Return: commit and move to next
-            self._commit_and_close()
+        if key in (16777220, 16777221):  # Enter / Return: save and move to next
+            self._save_and_close()
             next_row = self.currentRow() + 1
             if next_row < self.count():
                 self.setCurrentRow(next_row)
                 self.scrollToItem(self.item(next_row))
             event.accept()
             return
-        if key == 16777217:  # Tab (no editor open): just navigate
+        if key == 16777217:  # Tab with no editor open: just navigate
             next_row = self.currentRow() + 1
             if next_row < self.count():
                 self.setCurrentRow(next_row)
                 self.scrollToItem(self.item(next_row))
             event.accept()
             return
-        if key == 16777218:  # Shift+Tab (no editor open): just navigate back
+        if key == 16777218:  # Shift+Tab with no editor open: navigate back
             prev_row = self.currentRow() - 1
             if prev_row >= 0:
                 self.setCurrentRow(prev_row)

--- a/libs/editinlist.py
+++ b/libs/editinlist.py
@@ -26,8 +26,28 @@ class EditInList(QListWidget):
     def leaveEvent(self, event):
         pass
 
+    def activate_edit(self):
+        """Open persistent editor for the currently selected item (called by F2)."""
+        item = self.currentItem()
+        if item is None:
+            return
+        if self.edited_item is not None:
+            try:
+                self.closePersistentEditor(self.edited_item)
+            except Exception:
+                pass
+        self.edited_item = item
+        self.openPersistentEditor(item)
+        self.editItem(item)
+    
     def keyPressEvent(self, event) -> None:
         # close edit
-        if event.key() in [16777220, 16777221]:
+        if event.key() in [16777220, 16777221]:  # Enter / Return
             for i in range(self.count()):
                 self.closePersistentEditor(self.item(i))
+            # bir sonraki satıra geç ve editörü aç
+            next_row = self.currentRow() + 1
+            if next_row < self.count():
+                self.setCurrentRow(next_row)
+                self.scrollToItem(self.item(next_row))
+                self.activate_edit()

--- a/libs/shape.py
+++ b/libs/shape.py
@@ -77,6 +77,7 @@ class Shape(object):
             self.MOVE_VERTEX: (1.5, self.P_SQUARE),
         }
         self.fontsize = 8
+        self.score = None  # OCR confidence score (0.0-1.0), None if unknown
 
         self._closed = False
         self.font_family = font_family


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for navigating and editing OCR detection results without mouse clicks.

## Shortcuts added

| Key | Action |
|-----|--------|
| `Tab` | Next detection box |
| `Shift+Tab` | Previous detection box |
| `F2` | Open inline text editor for focused box |
| `Enter` | Confirm edit and move to next box |

## Motivation

When correcting OCR output on a dense document (50–200 boxes), the current workflow requires a mouse click for every single box. With these shortcuts, the entire correction pass can be done keyboard-only — Tab to navigate, F2 to edit, Enter to confirm and continue.

This pattern is standard in annotation tools (LabelImg, Label Studio, CVAT).

## Changes

- `PPOCRLabel.py`: Added `QShortcut` bindings for Tab/Shift+Tab/F2, added `_navigateLabel()` method
- `libs/editinlist.py`: Added `activate_edit()` method, Enter in edit mode now moves to next item

closes #261 