### PR TITLE
Fix OCR language model switching

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -140,6 +140,15 @@ logger = logging.getLogger("PPOCRLabel")
 
 __appname__ = "PPOCRLabel"
 
+DEFAULT_RECOGNITION_MODELS = {
+    "ch": "PP-OCRv5_mobile_rec",
+    "en": "en_PP-OCRv5_mobile_rec",
+    "french": "latin_PP-OCRv5_mobile_rec",
+    "german": "latin_PP-OCRv5_mobile_rec",
+    "korean": "korean_PP-OCRv5_mobile_rec",
+    "japan": "PP-OCRv5_server_rec",
+}
+
 LABEL_COLORMAP = label_colormap()
 
 
@@ -200,15 +209,24 @@ class MainWindow(QMainWindow):
         self.rec_model_dir = rec_model_dir
         self.rec_model_name = rec_model_name
         self.cls_model_dir = cls_model_dir
+        self.model_lang = self.lang if self.lang in DEFAULT_RECOGNITION_MODELS else "ch"
+        self.use_default_ocr_models = (
+            self.det_model_dir is None
+            and self.rec_model_dir is None
+            and self.det_model_name == "PP-OCRv5_mobile_det"
+            and self.rec_model_name == "PP-OCRv5_mobile_rec"
+        )
+        recognition_model_name = self.rec_model_name
+        if self.use_default_ocr_models:
+            recognition_model_name = DEFAULT_RECOGNITION_MODELS[self.model_lang]
 
         params = {
             "use_doc_orientation_classify": False,
             "use_doc_unwarping": False,
             "use_textline_orientation": False,
             "device": self.gpu,
-            "lang": self.lang,
             "text_detection_model_name": self.det_model_name,
-            "text_recognition_model_name": self.rec_model_name,
+            "text_recognition_model_name": recognition_model_name,
             "enable_mkldnn": False,
         }
 
@@ -221,7 +239,7 @@ class MainWindow(QMainWindow):
 
         self.ocr = PaddleOCR(**params)
         self.text_recognizer = TextRecognition(
-            model_name=self.rec_model_name,
+            model_name=recognition_model_name,
             model_dir=self.rec_model_dir,
             device=self.gpu,
         )
@@ -3574,6 +3592,17 @@ class MainWindow(QMainWindow):
         self.comboBox.addItems(
             ["Chinese & English", "English", "French", "German", "Korean", "Japanese"]
         )
+        model_labels = {
+            "ch": "Chinese & English",
+            "en": "English",
+            "french": "French",
+            "german": "German",
+            "korean": "Korean",
+            "japan": "Japanese",
+        }
+        self.comboBox.setCurrentText(
+            model_labels.get(self.model_lang, "Chinese & English")
+        )
         vbox.addWidget(self.panel)
         vbox.addWidget(self.comboBox)
         self.dialog = QDialog()
@@ -3611,14 +3640,16 @@ class MainWindow(QMainWindow):
         if current_text in lg_idx:
             choose_lang = lg_idx[current_text]
             if hasattr(self, "ocr"):
-                del self.ocr
+                rec_model_name = self.rec_model_name
+                if self.use_default_ocr_models:
+                    rec_model_name = DEFAULT_RECOGNITION_MODELS[choose_lang]
+
                 params = {
                     "use_doc_orientation_classify": False,
                     "use_textline_orientation": False,
                     "use_doc_unwarping": False,
                     "text_detection_model_name": self.det_model_name,
-                    "text_recognition_model_name": self.rec_model_name,
-                    "lang": choose_lang,
+                    "text_recognition_model_name": rec_model_name,
                     "device": self.gpu,
                 }
                 if self.det_model_dir is not None:
@@ -3628,7 +3659,14 @@ class MainWindow(QMainWindow):
                 if self.cls_model_dir is not None:
                     params["text_line_orientation_model_dir"] = self.cls_model_dir
 
-                self.ocr = PaddleOCR(**params)
+                selected_ocr = PaddleOCR(**params)
+                selected_text_recognizer = TextRecognition(
+                    model_name=rec_model_name,
+                    model_dir=self.rec_model_dir,
+                    device=self.gpu,
+                )
+                self.ocr = selected_ocr
+                self.text_recognizer = selected_text_recognizer
             if choose_lang in ["ch", "en"]:
                 if hasattr(self, "table_ocr"):
                     del self.table_ocr
@@ -3642,6 +3680,7 @@ class MainWindow(QMainWindow):
                     use_region_detection=False,
                     device=self.gpu,
                 )
+            self.model_lang = choose_lang
         else:
             logger.error("Invalid language selection")
         self.dialog.close()

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -149,6 +149,13 @@ DEFAULT_RECOGNITION_MODELS = {
     "japan": "PP-OCRv5_server_rec",
 }
 
+
+def getRecognitionModelName(lang, modelName, modelDir):
+    if modelDir is None and modelName == "PP-OCRv5_mobile_rec":
+        return DEFAULT_RECOGNITION_MODELS[lang]
+    return modelName
+
+
 LABEL_COLORMAP = label_colormap()
 
 
@@ -210,15 +217,9 @@ class MainWindow(QMainWindow):
         self.rec_model_name = rec_model_name
         self.cls_model_dir = cls_model_dir
         self.model_lang = self.lang if self.lang in DEFAULT_RECOGNITION_MODELS else "ch"
-        self.use_default_ocr_models = (
-            self.det_model_dir is None
-            and self.rec_model_dir is None
-            and self.det_model_name == "PP-OCRv5_mobile_det"
-            and self.rec_model_name == "PP-OCRv5_mobile_rec"
+        recognition_model_name = getRecognitionModelName(
+            self.model_lang, self.rec_model_name, self.rec_model_dir
         )
-        recognition_model_name = self.rec_model_name
-        if self.use_default_ocr_models:
-            recognition_model_name = DEFAULT_RECOGNITION_MODELS[self.model_lang]
 
         params = {
             "use_doc_orientation_classify": False,
@@ -3640,9 +3641,9 @@ class MainWindow(QMainWindow):
         if current_text in lg_idx:
             choose_lang = lg_idx[current_text]
             if hasattr(self, "ocr"):
-                rec_model_name = self.rec_model_name
-                if self.use_default_ocr_models:
-                    rec_model_name = DEFAULT_RECOGNITION_MODELS[choose_lang]
+                rec_model_name = getRecognitionModelName(
+                    choose_lang, self.rec_model_name, self.rec_model_dir
+                )
 
                 params = {
                     "use_doc_orientation_classify": False,
@@ -3651,6 +3652,7 @@ class MainWindow(QMainWindow):
                     "text_detection_model_name": self.det_model_name,
                     "text_recognition_model_name": rec_model_name,
                     "device": self.gpu,
+                    "enable_mkldnn": False,
                 }
                 if self.det_model_dir is not None:
                     params["text_detection_model_dir"] = self.det_model_dir

--- a/tests/test_model_language.py
+++ b/tests/test_model_language.py
@@ -1,0 +1,54 @@
+import ast
+import unittest
+from pathlib import Path
+
+
+sourcePath = Path(__file__).parents[1] / "PPOCRLabel.py"
+tree = ast.parse(sourcePath.read_text(encoding="utf-8"))
+nodes = [
+    node
+    for node in tree.body
+    if (
+        isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "DEFAULT_RECOGNITION_MODELS"
+            for target in node.targets
+        )
+    )
+    or (isinstance(node, ast.FunctionDef) and node.name == "getRecognitionModelName")
+]
+namespace = {}
+exec(compile(ast.Module(nodes, type_ignores=[]), str(sourcePath), "exec"), namespace)
+
+
+class ModelLanguageTest(unittest.TestCase):
+    def test_default_recognition_model_selection(self):
+        getModelName = namespace["getRecognitionModelName"]
+        self.assertEqual(
+            getModelName("en", "PP-OCRv5_mobile_rec", None),
+            "en_PP-OCRv5_mobile_rec",
+        )
+        self.assertEqual(getModelName("en", "custom_rec", None), "custom_rec")
+        self.assertEqual(
+            getModelName("en", "PP-OCRv5_mobile_rec", "custom_dir"),
+            "PP-OCRv5_mobile_rec",
+        )
+
+    def test_language_switch_keeps_mkldnn_disabled(self):
+        modelChoose = next(
+            node
+            for classNode in tree.body
+            if isinstance(classNode, ast.ClassDef) and classNode.name == "MainWindow"
+            for node in classNode.body
+            if isinstance(node, ast.FunctionDef) and node.name == "modelChoose"
+        )
+        self.assertTrue(
+            any(
+                isinstance(node, ast.Constant) and node.value == "enable_mkldnn"
+                for node in ast.walk(modelChoose)
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The language dialog passed both `lang` and fixed detection/recognition model names to `PaddleOCR`. PaddleOCR ignores `lang` when model names or directories are provided, so selecting another language did not actually switch the recognition model. The standalone `TextRecognition` instance used by re-recognition also remained on the old model.

## Changes

- map the six language choices to their PP-OCRv5 recognition models while keeping the existing mobile detection model
- initialize the default recognition model consistently with `--lang`
- rebuild both the full OCR pipeline and standalone recognizer when the selection changes
- preserve the current selection when reopening the language dialog
- keep custom model names/directories unchanged

## Verification

- `python -m py_compile PPOCRLabel.py`
- mock regression check: switching from Chinese to English selects `en_PP-OCRv5_mobile_rec` for both `PaddleOCR` and `TextRecognition`, keeps `PP-OCRv5_mobile_det`, and restores English in the dialog
- `git diff --check`
