### PR TITLE
Move deleted images to trash and clean metadata

### DIFF
--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -157,7 +157,9 @@ def moveFileToTrash(filePath):
 
         operation = SHFILEOPSTRUCTW()
         operation.wFunc = 3  # FO_DELETE
-        operation.pFrom = os.path.abspath(filePath) + "\0"
+        fromPath = os.path.abspath(filePath) + "\0\0"
+        fromBuffer = ctypes.create_unicode_buffer(fromPath)
+        operation.pFrom = ctypes.cast(fromBuffer, wintypes.LPCWSTR)
         operation.fFlags = 0x0040 | 0x0010 | 0x0004 | 0x0400
         result = ctypes.windll.shell32.SHFileOperationW(ctypes.byref(operation))
         return result == 0 and not operation.fAnyOperationsAborted

--- a/PPOCRLabel.py
+++ b/PPOCRLabel.py
@@ -138,6 +138,47 @@ import logging
 logger = logging.getLogger("PPOCRLabel")
 
 
+def moveFileToTrash(filePath):
+    if platform.system() == "Windows":
+        import ctypes
+        from ctypes import wintypes
+
+        class SHFILEOPSTRUCTW(ctypes.Structure):
+            _fields_ = [
+                ("hwnd", wintypes.HWND),
+                ("wFunc", wintypes.UINT),
+                ("pFrom", wintypes.LPCWSTR),
+                ("pTo", wintypes.LPCWSTR),
+                ("fFlags", ctypes.c_ushort),
+                ("fAnyOperationsAborted", wintypes.BOOL),
+                ("hNameMappings", ctypes.c_void_p),
+                ("lpszProgressTitle", wintypes.LPCWSTR),
+            ]
+
+        operation = SHFILEOPSTRUCTW()
+        operation.wFunc = 3  # FO_DELETE
+        operation.pFrom = os.path.abspath(filePath) + "\0"
+        operation.fFlags = 0x0040 | 0x0010 | 0x0004 | 0x0400
+        result = ctypes.windll.shell32.SHFileOperationW(ctypes.byref(operation))
+        return result == 0 and not operation.fAnyOperationsAborted
+
+    if platform.system() == "Linux":
+        return subprocess.call(["trash", filePath]) == 0
+
+    if platform.system() == "Darwin":
+        absPath = os.path.abspath(filePath).replace("\\", "\\\\").replace('"', '\\"')
+        cmd = [
+            "osascript",
+            "-e",
+            'tell app "Finder" to move {the POSIX file "' + absPath + '"} to trash',
+        ]
+        logger.debug("Executing command: %s", " ".join(cmd))
+        with open(os.devnull, "w") as devnull:
+            return subprocess.call(cmd, stdout=devnull) == 0
+
+    return False
+
+
 __appname__ = "PPOCRLabel"
 
 LABEL_COLORMAP = label_colormap()
@@ -2831,41 +2872,27 @@ class MainWindow(QMainWindow):
         if deletePath is not None:
             deleteInfo = self.deleteImgDialog()
             if deleteInfo == QMessageBox.Yes:
-                if platform.system() == "Windows":
-                    # from win32com import shell, shellcon
-                    # shell.SHFileOperation((0, shellcon.FO_DELETE, deletePath, None,
-                    #                        shellcon.FOF_SILENT | shellcon.FOF_ALLOWUNDO | shellcon.FOF_NOCONFIRMATION,
-                    #                        None, None))
-                    os.remove(deletePath)
-                    # linux
-                elif platform.system() == "Linux":
-                    cmd = "trash " + deletePath
-                    os.system(cmd)
-                    # macOS
-                elif platform.system() == "Darwin":
-                    import subprocess
+                imgidx = self.getImglabelidx(deletePath)
+                try:
+                    deleteSucceeded = moveFileToTrash(deletePath)
+                except Exception as error:
+                    logger.exception("Failed to move image to trash: %s", error)
+                    deleteSucceeded = False
 
-                    absPath = (
-                        os.path.abspath(deletePath)
-                        .replace("\\", "\\\\")
-                        .replace('"', '\\"')
+                if not deleteSucceeded:
+                    QMessageBox.warning(
+                        self,
+                        "Attention",
+                        "The image could not be moved to the recycle bin.",
                     )
-                    cmd = [
-                        "osascript",
-                        "-e",
-                        'tell app "Finder" to move {the POSIX file "'
-                        + absPath
-                        + '"} to trash',
-                    ]
-                    logger.debug("Executing command: %s", " ".join(cmd))
-                    subprocess.call(cmd, stdout=open(os.devnull, "w"))
+                    return
 
-                if self.filePath in self.fileStatedict.keys():
-                    self.fileStatedict.pop(self.filePath)
-                imgidx = self.getImglabelidx(self.filePath)
-                if imgidx in self.PPlabel.keys():
-                    self.PPlabel.pop(imgidx)
-
+                self.fileStatedict.pop(imgidx, None)
+                self.PPlabel.pop(imgidx, None)
+                self.Cachelabel.pop(imgidx, None)
+                self.saveFilestate()
+                self.savePPlabel(mode="Auto")
+                self.saveCacheLabel()
                 self.importDirImages(self.lastOpenDir, isDelete=True)
 
     def deleteImgDialog(self):

--- a/tests/test_windows_trash.py
+++ b/tests/test_windows_trash.py
@@ -1,0 +1,45 @@
+import ast
+import os
+import platform
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sourcePath = Path(__file__).parents[1] / "PPOCRLabel.py"
+tree = ast.parse(sourcePath.read_text(encoding="utf-8"))
+moveFunction = next(
+    node
+    for node in tree.body
+    if isinstance(node, ast.FunctionDef) and node.name == "moveFileToTrash"
+)
+namespace = {
+    "os": os,
+    "platform": platform,
+    "subprocess": subprocess,
+    "logger": type("Logger", (), {"debug": staticmethod(lambda *_args: None)})(),
+}
+exec(
+    compile(ast.Module([moveFunction], type_ignores=[]), str(sourcePath), "exec"),
+    namespace,
+)
+
+
+class WindowsTrashTest(unittest.TestCase):
+    @unittest.skipUnless(platform.system() == "Windows", "Windows-only check")
+    def test_explicit_path_buffer(self):
+        with tempfile.NamedTemporaryFile(
+            prefix="ppocrlabel_trash_", delete=False
+        ) as file:
+            tempPath = Path(file.name)
+
+        try:
+            self.assertTrue(namespace["moveFileToTrash"](str(tempPath)))
+            self.assertFalse(tempPath.exists())
+        finally:
+            tempPath.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The delete confirmation says that an image will be moved to the recycle bin, but Windows used `os.remove`, which permanently deleted it. After deletion, the code also removed the wrong `fileStatedict` key and only changed `PPlabel` in memory. `fileState.txt`, `Label.txt`, and `Cache.cach` could therefore retain references to a missing image, and `Cache.cach` could restore that stale entry on the next launch.

## Changes

- move files to the recycle bin on Windows with the standard-library `SHFileOperationW` API
- use argument lists for Linux trash invocation and keep the existing Finder behavior on macOS
- stop without changing metadata when moving the file to trash fails
- remove the normalized image key from `fileStatedict`, `PPlabel`, and `Cachelabel`
- persist all three metadata files before refreshing the image list

No additional dependency is introduced.

## Verification

- real Windows temporary-file check confirmed that the file is removed through the recycle-bin operation
- mock regression check confirmed successful deletion cleans and saves all three metadata stores
- mock failure check confirmed metadata remains unchanged when the file cannot be moved
- `python -m py_compile PPOCRLabel.py`
- `git diff --check`
